### PR TITLE
Retrieve Chapter Information

### DIFF
--- a/lib/skrap/content/chapter.ex
+++ b/lib/skrap/content/chapter.ex
@@ -1,0 +1,10 @@
+defmodule Skrap.Content.Chapter do
+  defstruct added_at: nil, id: nil, name: nil, uri: nil
+
+  @type t :: %__MODULE__{
+          added_at: Date.t(),
+          id: binary(),
+          name: String.t(),
+          uri: String.t()
+        }
+end

--- a/lib/skrap/content/manga.ex
+++ b/lib/skrap/content/manga.ex
@@ -1,8 +1,11 @@
 defmodule Skrap.Content.Manga do
-  defstruct author: nil, cover_url: nil, id: nil, illustrator: nil, name: nil
+  defstruct author: nil, chapters: [], cover_url: nil, id: nil, illustrator: nil, name: nil
+
+  alias Skrap.Content.Chapter
 
   @type t :: %__MODULE__{
           author: String.t(),
+          chapters: list(Chapter.t()),
           cover_url: String.t(),
           id: binary(),
           illustrator: String.t(),

--- a/lib/skrap/helpers/date_helper.ex
+++ b/lib/skrap/helpers/date_helper.ex
@@ -1,0 +1,28 @@
+defmodule Skrap.DateHelper do
+  @spec parse_readable_date(String.t()) :: {:ok, Date.t()} | {:error, term()}
+  def parse_readable_date(
+        <<m1::utf8, m2::utf8, m3::utf8, " ", d1::utf8, d2::utf8, ", ", year::binary>>
+      ) do
+    day = [d1, d2] |> to_string() |> String.to_integer()
+    month = [m1, m2, m3] |> to_string() |> parse_month()
+    year = String.to_integer(year)
+
+    date = Date.new!(year, month, day)
+    {:ok, date}
+  end
+
+  def parse_readable_date(_), do: {:error, :invalid_date_format}
+
+  defp parse_month("Jan"), do: 1
+  defp parse_month("Feb"), do: 2
+  defp parse_month("Mar"), do: 3
+  defp parse_month("Apr"), do: 4
+  defp parse_month("May"), do: 5
+  defp parse_month("Jun"), do: 6
+  defp parse_month("Jul"), do: 7
+  defp parse_month("Aug"), do: 8
+  defp parse_month("Sep"), do: 9
+  defp parse_month("Oct"), do: 10
+  defp parse_month("Nov"), do: 11
+  defp parse_month("Dec"), do: 12
+end

--- a/lib/skrap/host/manga_host/parser.ex
+++ b/lib/skrap/host/manga_host/parser.ex
@@ -58,6 +58,15 @@ defmodule Skrap.Host.MangaHost.Parser do
     Parser.validate_field({:name, name})
   end
 
+  def summary(html_tree) do
+    html_tree
+    |> Floki.find(".chapters > .cap")
+    |> Enum.map(&chapter/1)
+    |> Enum.reject(&match?({:error, _}, &1))
+    |> Enum.map(fn {:ok, chapter} -> chapter end)
+    |> Enum.reverse()
+  end
+
   def chapter(html_node) do
     with {:ok, added_at} <- get_added_at(html_node),
          {:ok, id} <- get_chapter_id(html_node),

--- a/lib/skrap/host/manga_host/parser.ex
+++ b/lib/skrap/host/manga_host/parser.ex
@@ -5,6 +5,7 @@ defmodule Skrap.Host.MangaHost.Parser do
 
   @behaviour Parser
 
+  @impl Parser
   def manga(html_tree) do
     with {:ok, cover_url} <- get_cover_url(html_tree),
          {:ok, author_name} <- get_author_name(html_tree),
@@ -58,6 +59,7 @@ defmodule Skrap.Host.MangaHost.Parser do
     Parser.validate_field({:name, name})
   end
 
+  @impl Parser
   def summary(html_tree) do
     html_tree
     |> Floki.find(".chapters > .cap")
@@ -67,6 +69,7 @@ defmodule Skrap.Host.MangaHost.Parser do
     |> Enum.reverse()
   end
 
+  @impl Parser
   def chapter(html_node) do
     with {:ok, added_at} <- get_added_at(html_node),
          {:ok, id} <- get_chapter_id(html_node),

--- a/lib/skrap/host/parser.ex
+++ b/lib/skrap/host/parser.ex
@@ -14,7 +14,7 @@ defmodule Skrap.Host.Parser do
 
   @callback manga(Floki.html_tree()) :: ok(Manga.t()) | error
   @callback summary(Floki.html_tree()) :: list(Chapter.t())
-  @callback chapter(Floki.html_node()) :: ok(Chapter.t()) | error
+  @callback chapter(binary() | Floki.html_node()) :: ok(Chapter.t()) | error
 
   @invalid_field_values [nil, ""]
 

--- a/lib/skrap/host/parser.ex
+++ b/lib/skrap/host/parser.ex
@@ -13,7 +13,7 @@ defmodule Skrap.Host.Parser do
   @type maybe_string :: String.t() | nil
 
   @callback manga(Floki.html_tree()) :: ok(Manga.t()) | error
-  @callback chapters(Floki.html_tree()) :: list(Chapter.t())
+  @callback summary(Floki.html_tree()) :: list(Chapter.t())
   @callback chapter(Floki.html_node()) :: ok(Chapter.t()) | error
 
   @invalid_field_values [nil, ""]

--- a/lib/skrap/host/parser.ex
+++ b/lib/skrap/host/parser.ex
@@ -5,7 +5,7 @@ defmodule Skrap.Host.Parser do
   A parser is responsible for extracting information of a host.
   """
 
-  alias Skrap.Content.Manga
+  alias Skrap.Content.{Chapter, Manga}
 
   @type ok(value) :: {:ok, value}
   @type error(reason) :: {:error, reason}
@@ -13,6 +13,8 @@ defmodule Skrap.Host.Parser do
   @type maybe_string :: String.t() | nil
 
   @callback manga(Floki.html_tree()) :: ok(Manga.t()) | error
+  @callback chapters(Floki.html_tree()) :: list(Chapter.t())
+  @callback chapter(Floki.html_node()) :: ok(Chapter.t()) | error
 
   @invalid_field_values [nil, ""]
 

--- a/test/skrap/host/manga_host/parser_test.exs
+++ b/test/skrap/host/manga_host/parser_test.exs
@@ -39,4 +39,32 @@ defmodule Skrap.Host.MangaHost.ParserTest do
       assert {:error, {:added_at, :invalid_date_format}} == Parser.chapter(empty_html_tree)
     end
   end
+
+  describe "summary/1" do
+    test "returns a list of chapters" do
+      %{data: data, content: content} = HostContent.manga_host(:summary)
+
+      chapters = Parser.summary(content)
+      assert data.length == Enum.count(chapters)
+    end
+
+    test "returns a list of valid chapters when some chapters could not be parsed" do
+      invalid_chapter = {}
+      invalid_chapters = [invalid_chapter]
+      invalid_chapters_length = Enum.count(invalid_chapters)
+
+      %{data: data, content: content} =
+        HostContent.manga_host(:summary, chapters: invalid_chapters)
+
+      chapters = Parser.summary(content)
+
+      valid_chapters_length = data.length - invalid_chapters_length
+      assert valid_chapters_length == Enum.count(chapters)
+    end
+
+    test "returns an empty list when there no item could be parsed" do
+      empty_html_tree = []
+      assert [] == Parser.summary(empty_html_tree)
+    end
+  end
 end

--- a/test/skrap/host/manga_host/parser_test.exs
+++ b/test/skrap/host/manga_host/parser_test.exs
@@ -34,7 +34,7 @@ defmodule Skrap.Host.MangaHost.ParserTest do
       assert chapter.uri == data.uri
     end
 
-    test "returns and error with a reason when some information could not be parsed" do
+    test "returns an error with a reason when some information could not be parsed" do
       empty_html_tree = []
       assert {:error, {:added_at, :invalid_date_format}} == Parser.chapter(empty_html_tree)
     end
@@ -48,7 +48,7 @@ defmodule Skrap.Host.MangaHost.ParserTest do
       assert data.length == Enum.count(chapters)
     end
 
-    test "returns a list of valid chapters when some chapters could not be parsed" do
+    test "returns a list of chapters when some chapters could not be parsed" do
       invalid_chapter = {}
       invalid_chapters = [invalid_chapter]
       invalid_chapters_length = Enum.count(invalid_chapters)
@@ -62,7 +62,7 @@ defmodule Skrap.Host.MangaHost.ParserTest do
       assert valid_chapters_length == Enum.count(chapters)
     end
 
-    test "returns an empty list when there no item could be parsed" do
+    test "returns an empty list when no chapter could be parsed" do
       empty_html_tree = []
       assert [] == Parser.summary(empty_html_tree)
     end

--- a/test/skrap/host/manga_host/parser_test.exs
+++ b/test/skrap/host/manga_host/parser_test.exs
@@ -1,7 +1,7 @@
 defmodule Skrap.Host.MangaHost.ParserTest do
   use ExUnit.Case, async: true
 
-  alias Skrap.Content.Manga
+  alias Skrap.Content.{Chapter, Manga}
   alias Skrap.Host.MangaHost.Parser
 
   alias Skrap.Factory.HostContent
@@ -20,6 +20,23 @@ defmodule Skrap.Host.MangaHost.ParserTest do
     test "returns an error with a reason when some information could not be parsed" do
       empty_html_tree = []
       assert {:error, {:cover_url, :field_not_found}} == Parser.manga(empty_html_tree)
+    end
+  end
+
+  describe "chapter/1" do
+    test "returns ok with all parsed information" do
+      %{data: data, content: content} = HostContent.manga_host(:chapter)
+
+      assert {:ok, %Chapter{} = chapter} = Parser.chapter(content)
+      assert chapter.added_at == data.added_at
+      assert chapter.id == data.id
+      assert chapter.name == data.name
+      assert chapter.uri == data.uri
+    end
+
+    test "returns and error with a reason when some information could not be parsed" do
+      empty_html_tree = []
+      assert {:error, {:added_at, :invalid_date_format}} == Parser.chapter(empty_html_tree)
     end
   end
 end

--- a/test/support/host_content_factory.ex
+++ b/test/support/host_content_factory.ex
@@ -1,5 +1,5 @@
 defmodule Skrap.Factory.HostContent do
-  alias Faker.{Internet, Person, Superhero}
+  alias Faker.{Date, Internet, Person, Superhero, UUID}
 
   def manga_host(:manga, opts \\ []) do
     author = Keyword.get_lazy(opts, :author, &Person.name/0)
@@ -72,6 +72,67 @@ defmodule Skrap.Factory.HostContent do
         name: name
       },
       content: content
+    }
+  end
+
+  def manga_host(:chapter, opts \\ []) do
+    random_date_fn = fn -> 1000 |> :rand.uniform() |> Date.backward() end
+    name_prefix = "Capítulo "
+
+    added_at = Keyword.get_lazy(opts, :added_at, random_date_fn)
+    id = Keyword.get_lazy(opts, :id, &UUID.v4/0)
+    name = Keyword.get(opts, :name, name_prefix <> id)
+    uri = Keyword.get_lazy(opts, :uri, &Internet.url/0)
+
+    formatted_added_at = Calendar.strftime(added_at, "%b %0d, %Y")
+
+    content = [
+      {"div", [{"id", "pop-#{id}"}, {"class", "cap"}],
+       [
+         {"div", [{"class", "card pop"}],
+          [
+            {"div", [{"class", "pop-title"}],
+             [name_prefix, {"span", [{"class", "btn-caps"}], [id]}]},
+            {"div", [{"class", "pop-content"}],
+             [
+               {"small", [{"class", "clearfix"}],
+                [
+                  "Traduzido por ",
+                  {"strong", [], [Person.name()]},
+                  {"br", [], []},
+                  "\nAdicionado em #{formatted_added_at}"
+                ]},
+               {"div", [{"class", "tags"}],
+                [
+                  {"a",
+                   [
+                     {"href", uri},
+                     {"title", "Ler Online - #{name} []"},
+                     {"class", "btn-green w-button pull-left"}
+                   ], [{"i", [{"class", "icon-file"}], []}, " Ler Online"]}
+                ]}
+             ]}
+          ]},
+         {"a",
+          [
+            {"class", "btn-caps w-button"},
+            {"rel", "popover"},
+            {"href", "javascript:void(0)"},
+            {"data-pop", "#pop-#{id}"},
+            {"id", id},
+            {"title", name}
+          ], [id]}
+       ]}
+    ]
+
+    %{
+      content: content,
+      data: %{
+        added_at: added_at,
+        id: id,
+        name: name,
+        uri: uri
+      }
     }
   end
 end

--- a/test/support/host_content_factory.ex
+++ b/test/support/host_content_factory.ex
@@ -1,7 +1,9 @@
 defmodule Skrap.Factory.HostContent do
   alias Faker.{Date, Internet, Person, Superhero, UUID}
 
-  def manga_host(:manga, opts \\ []) do
+  def manga_host(resource, opts \\ [])
+
+  def manga_host(:manga, opts) do
     author = Keyword.get_lazy(opts, :author, &Person.name/0)
     cover_url = Keyword.get_lazy(opts, :cover_url, &Internet.image_url/0)
     illustrator = Keyword.get_lazy(opts, :illustrator, &Person.name/0)
@@ -75,7 +77,7 @@ defmodule Skrap.Factory.HostContent do
     }
   end
 
-  def manga_host(:chapter, opts \\ []) do
+  def manga_host(:chapter, opts) do
     random_date_fn = fn -> 1000 |> :rand.uniform() |> Date.backward() end
     name_prefix = "Capítulo "
 

--- a/test/support/host_content_factory.ex
+++ b/test/support/host_content_factory.ex
@@ -137,4 +137,29 @@ defmodule Skrap.Factory.HostContent do
       }
     }
   end
+
+  def manga_host(:summary, opts) do
+    random_length_fn = fn -> :rand.uniform(10) end
+
+    random_chapters_length = Keyword.get_lazy(opts, :length, random_length_fn)
+    chapters = Keyword.get(opts, :chapters, [])
+
+    random_chapters =
+      1..random_chapters_length
+      |> Enum.to_list()
+      |> Enum.map(fn _ -> manga_host(:chapter) end)
+      |> Enum.flat_map(& &1.content)
+
+    chapters_content = random_chapters ++ chapters
+
+    content = [{"div", [{"class", "chapters"}], chapters_content}]
+    length = Enum.count(random_chapters) + Enum.count(chapters)
+
+    %{
+      content: content,
+      data: %{
+        length: length
+      }
+    }
+  end
 end


### PR DESCRIPTION
#### Why is this PR necessary?
We need a way to reach (and parse) the chapters pages, the manga index page seems to be a great entry point to do so, at least on Manga Host since it has a list of all chapters with the information we need such as "reading URL" (which leads us to the chapter pages).

#### Who benefits from this?
Because there's no way to interact with the code, only developers benefit from this PR (in this case, just me :v).

#### What could go wrong?
At this point, nothing except the index page structure changing which would break our parsing logic.

#### What other approaches did you consider? Why did you decide on this approach?
I didn't considered any other approaches because this just extends the current structure to parse chapter information.

